### PR TITLE
Search for libEGL only in the application dir on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Avoid loading libEGL.dll from PATH on Windows.
+
 # Version 0.24.0 (2020-03-11)
 
 - Updated winit dependency to 0.22.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0220-2020-03-09) for more info.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -48,7 +48,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-libloading = { git = "https://github.com/NightRa/rust_libloading.git" }
+libloading = "0.6.1"
 glutin_wgl_sys = { version = "0.1.4", path = "../glutin_wgl_sys" }
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 parking_lot = "0.10"
@@ -56,7 +56,7 @@ parking_lot = "0.10"
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 osmesa-sys = "0.1"
 wayland-client = { version = "0.23", features = ["egl", "dlopen"] }
-libloading = { git = "https://github.com/NightRa/rust_libloading.git" }
+libloading = "0.6.1"
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 glutin_glx_sys = { version = "0.1.6", path = "../glutin_glx_sys" }
 parking_lot = "0.10"

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -48,7 +48,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-libloading = "0.5"
+libloading = { git = "https://github.com/NightRa/rust_libloading.git" }
 glutin_wgl_sys = { version = "0.1.4", path = "../glutin_wgl_sys" }
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 parking_lot = "0.10"
@@ -56,7 +56,7 @@ parking_lot = "0.10"
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 osmesa-sys = "0.1"
 wayland-client = { version = "0.23", features = ["egl", "dlopen"] }
-libloading = "0.5"
+libloading = { git = "https://github.com/NightRa/rust_libloading.git" }
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 glutin_glx_sys = { version = "0.1.6", path = "../glutin_glx_sys" }
 parking_lot = "0.10"


### PR DESCRIPTION
Would be glad if you could upstream it later when `rust_libloading` is updated & released.